### PR TITLE
Use `Compose` from transformers package for (Functor f) compositions

### DIFF
--- a/Data/Functor/Contravariant.hs
+++ b/Data/Functor/Contravariant.hs
@@ -37,6 +37,7 @@ module Data.Functor.Contravariant (
 
 import Control.Applicative
 import Data.Functor.Product
+import Data.Functor.Compose
 import Data.Functor.Constant
 
 -- | Any instance should be subject to the following laws:
@@ -106,6 +107,11 @@ instance (Contravariant f, Contravariant g) => Contravariant (Product f g) where
 -- | Data.Functor.Constant
 instance Contravariant (Constant a) where
   contramap _ (Constant a) = Constant a
+
+-- | Data.Functor.Compose (see Data.Functor.Contravariant.Compose for
+-- compositions of Contravariant functors with other functor types)
+instance (Functor f, Contravariant g) => Contravariant (Compose f g) where
+    contramap f (Compose x) = Compose (fmap (contramap f) x)
 
 -- | Control.Applicative.Const
 instance Contravariant (Const a) where

--- a/Data/Functor/Contravariant/Compose.hs
+++ b/Data/Functor/Contravariant/Compose.hs
@@ -11,27 +11,16 @@
 
 module Data.Functor.Contravariant.Compose 
   ( Compose(..)
-  , ComposeFC(..)
-  , ComposeCF(..)
   ) where
 
 import Data.Functor.Contravariant
 
--- | Composition of two contravariant functors
+-- | A Contravariant functor composed with another functor type
 newtype Compose f g a = Compose { getCompose :: f (g a) }
 
 instance (Contravariant f, Contravariant g) => Functor (Compose f g) where
     fmap f (Compose x) = Compose (contramap (contramap f) x)
 
--- | Composition of covariant and contravariant functors
-newtype ComposeFC f g a = ComposeFC { getComposeFC :: f (g a) } 
-
-instance (Functor f, Contravariant g) => Contravariant (ComposeFC f g) where
-    contramap f (ComposeFC x) = ComposeFC (fmap (contramap f) x)
-
--- | Composition of contravariant and covariant functors
-newtype ComposeCF f g a = ComposeCF { getComposeCF :: f (g a) } 
-
-instance (Contravariant f, Functor g) => Contravariant (ComposeCF f g) where
-    contramap f (ComposeCF x) = ComposeCF (contramap (fmap f) x)
+instance (Contravariant f, Functor g) => Contravariant (Compose f g) where
+    contramap f (Compose x) = Compose (contramap (fmap f) x)
 


### PR DESCRIPTION
Hi Edward,
I'm learning a lot looking at your module.

I wonder what you think of this: we treat `Compose` from the transformers package as the composition of a _covariant_ functor with another functor type, and export our own `Compose` type for compositions of contravariant functors with another functor type.

This makes sense to me, since users of transformer's `Compose` might be passing around something like:

```
F.Compose . Just
```

and the above would get nice instances when applied to either a Functor or a Contravariant now.

Brandon
