### PR TITLE
Fix build on GHC 7.2

### DIFF
--- a/contravariant.cabal
+++ b/contravariant.cabal
@@ -63,7 +63,7 @@ library
   if flag(StateVar)
     build-depends: StateVar >= 1.1 && < 1.2
 
-  if impl(ghc >= 7.4 && < 7.6)
+  if impl(ghc >= 7.2 && < 7.6)
     build-depends: ghc-prim
 
   exposed-modules:

--- a/src/Data/Functor/Contravariant.hs
+++ b/src/Data/Functor/Contravariant.hs
@@ -14,7 +14,7 @@
 #define MIN_VERSION_base(x,y,z) 1
 #endif
 
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 704
 #if MIN_VERSION_transformers(0,3,0) && MIN_VERSION_tagged(0,6,1)
 {-# LANGUAGE Safe #-}
 #else
@@ -258,7 +258,7 @@ defaultComparison = Comparison compare
 -- @
 --
 -- __Symmetry__:
--- 
+--
 -- @
 -- 'getEquivalence' f a b = 'getEquivalence' f b a
 -- @


### PR DESCRIPTION
```
src/Data/Functor/Contravariant.hs:101:8:
    Could not find module `GHC.Generics'
    It is a member of the hidden package `ghc-prim'.
    Perhaps you need to add `ghc-prim' to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
```

```
Preprocessing library contravariant-1.3.1...
[1 of 3] Compiling Data.Functor.Contravariant ( src/Data/Functor/Contravariant.hs, dist/dist-sandbox-c66cf055/build/Data/Functor/Contravariant.o )

src/Data/Functor/Contravariant.hs:96:1:
    StateVar-1.1.0.0:Data.StateVar can't be safely imported! The module itself isn't safe.
```

