### PR TITLE
Make SettableStateVar instances for Decidable and Divisible visible

### DIFF
--- a/src/Data/Functor/Contravariant/Divisible.hs
+++ b/src/Data/Functor/Contravariant/Divisible.hs
@@ -56,7 +56,7 @@ import Data.Monoid (Monoid(..))
 import Data.Proxy
 #endif
 
-#if MIN_VERSION_StateVar
+#ifdef MIN_VERSION_StateVar
 import Data.StateVar
 #endif
 
@@ -280,7 +280,7 @@ instance Divisible Proxy where
   conquer = Proxy
 #endif
 
-#if MIN_VERSION_StateVar
+#ifdef MIN_VERSION_StateVar
 instance Divisible SettableStateVar where
   divide k (SettableStateVar l) (SettableStateVar r) = SettableStateVar $ \ a -> case k a of
     (b, c) -> l b >> r c
@@ -483,7 +483,7 @@ instance Decidable Proxy where
   choose _ Proxy Proxy = Proxy
 #endif
 
-#if MIN_VERSION_StateVar
+#ifdef MIN_VERSION_StateVar
 instance Decidable SettableVar where
   lose k = SettableStateVar (absurd . k)
   choose k (SettableStateVar l) (SettableStateVar r) = SettableStateVar $ \ a -> case k a of

--- a/src/Data/Functor/Contravariant/Divisible.hs
+++ b/src/Data/Functor/Contravariant/Divisible.hs
@@ -484,7 +484,7 @@ instance Decidable Proxy where
 #endif
 
 #ifdef MIN_VERSION_StateVar
-instance Decidable SettableVar where
+instance Decidable SettableStateVar where
   lose k = SettableStateVar (absurd . k)
   choose k (SettableStateVar l) (SettableStateVar r) = SettableStateVar $ \ a -> case k a of
     Left b -> l b


### PR DESCRIPTION
```haskell
import Data.StateVar
import Data.Functor.Contravariant
import Data.Functor.Contravariant.Divisible

-- No instance for (Decidable SettableStateVar)
ssv1 :: SettableStateVar String
ssv1 = lose (\_ -> undefined)

-- No instance for (Divisible SettableStateVar)
ssv2 :: SettableStateVar String
ssv2 = conquer

-- Typechecks without error, meaning the Contravariant instance is visible
contra :: SettableStateVar String
contra = contramap length (makeSettableStateVar undefined :: SettableStateVar Int)
```

Compiling the above program reveals that the `Decidable` and `Divisible` instances do not exist for `SettableStateVar` even though they are clearly defined in the `Data.Functor.Contravariant.Divisible`. The problem is the use of `#if MIN_VERSION_StateVar` instead of `#ifdef MIN_VERSION_StateVar`.

This extremely subtle bug was discovered when trying to compile `contravariant` with Eta and it resulted in a `cpphs` failure.

This PR fixes the problem.