### PR TITLE
tidy up dependencies

### DIFF
--- a/contravariant.cabal
+++ b/contravariant.cabal
@@ -65,8 +65,10 @@ library
   hs-source-dirs: src
   build-depends:
     base                              < 5,
-    transformers        >= 0.2 &&     < 0.6,
-    transformers-compat >= 0.3 &&     < 1
+    transformers        >= 0.2 &&     < 0.6
+
+  if impl(ghc <= 7.8)
+    build-depends: transformers-compat >= 0.3 && < 1
 
   if !impl(ghc >= 7.9)
     build-depends: void >= 0.6 &&     < 1

--- a/contravariant.cabal
+++ b/contravariant.cabal
@@ -67,7 +67,7 @@ library
     base                              < 5,
     transformers        >= 0.2 &&     < 0.6
 
-  if impl(ghc <= 7.8)
+  if !impl(ghc > 7.8)
     build-depends: transformers-compat >= 0.3 && < 1
 
   if !impl(ghc >= 7.9)


### PR DESCRIPTION
Removes a dependency on `transformers-compat` for new versions of GHC.