### PR TITLE
Make everything safe

### DIFF
--- a/src/Data/Functor/Contravariant/Generic.hs
+++ b/src/Data/Functor/Contravariant/Generic.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE CPP #-}
-#ifdef SAFE
-{-# LANGUAGE BangPatterns #-}
-#elif __GLASGOW_HASKELL__ >= 704
-{-# LANGUAGE Trustworthy #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Safe #-}
 #endif
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ConstraintKinds #-}
@@ -13,6 +11,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 #if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
+#endif
+{-# LANGUAGE TypeFamilies #-}
+#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE EmptyCase #-}
 #endif
 -----------------------------------------------------------------------------
 -- |
@@ -36,9 +38,6 @@ module Data.Functor.Contravariant.Generic
 import Data.Functor.Contravariant
 import Data.Functor.Contravariant.Divisible
 import GHC.Generics
-#ifndef SAFE
-import Unsafe.Coerce
-#endif
 
 -- | This provides machinery for deconstructing an arbitrary 'Generic' instance using a 'Decidable' 'Contravariant' functor.
 --
@@ -53,13 +52,52 @@ import Unsafe.Coerce
 -- geq :: 'Deciding' 'Eq' a => a -> a -> 'Bool'
 -- geq = 'getEquivalence' $ 'deciding' (Proxy :: Proxy 'Eq') ('Equivalence' ('=='))
 -- @
-class (Generic a, GDeciding q (Rep a)) => Deciding q a where
+class (Generic a, GDeciding q (Rep' a)) => Deciding q a where
 #ifndef HLINT
   deciding :: Decidable f => p q -> (forall b. q b => f b) -> f a
 #endif
 
-instance (Generic a, GDeciding q (Rep a)) => Deciding q a  where
-  deciding p q = contramap from $ gdeciding p q
+instance (Generic a, GG (Rep a), GDeciding q (Rep' a)) => Deciding q a  where
+  deciding p q = contramap (swizzle . from) $ gdeciding p q
+
+type Rep' a = Swizzle (Rep a)
+type Rep1' f = Swizzle (Rep1 f)
+type family Swizzle (r :: * -> *) :: * -> *
+type instance Swizzle (M1 i c f) = M1 i c (Swizzle f)
+type instance Swizzle V1 = V1
+type instance Swizzle U1 = U1
+type instance Swizzle Par1 = Par1
+type instance Swizzle (Rec1 f) = Rec1 f
+type instance Swizzle (K1 i c) = K1 i c
+type instance Swizzle (f :+: g) = Swizzle f ::+: Swizzle g
+type instance Swizzle (f :*: g) = Swizzle f ::*: Swizzle g
+type instance Swizzle (f :.: g) = f :.: Swizzle g
+
+newtype (::+:) f g a = Sum {unSum :: Either (f a) (g a)}
+newtype (::*:) f g a = Prod {unProd :: (f a, g a)}
+
+class GG r where
+  swizzle :: r p -> Swizzle r p
+instance GG f => GG (M1 i c f) where
+  swizzle (M1 a) = M1 (swizzle a)
+instance GG V1 where swizzle v = v
+instance GG U1 where swizzle v = v
+instance GG (K1 i c) where swizzle v = v
+instance GG Par1 where swizzle v = v
+instance GG (Rec1 f) where swizzle v = v
+instance (GG f, GG g) => GG (f :+: g) where
+  {-# INLINE swizzle #-}
+  swizzle (L1 x) = Sum (Left (swizzle x))
+  swizzle (R1 x) = Sum (Right (swizzle x))
+instance (GG f, GG g) => GG (f :*: g) where
+  {-# INLINE swizzle #-}
+  swizzle (x :*: y) = Prod (swizzle x, swizzle y)
+{-
+-- This instance wouldn't be that efficient. But we don't
+-- offer instances for compositions anyway.
+instance (Functor f, GG g) => GG (f :.: g) where
+  swizzle (Comp1 x) = Comp1 (fmap swizzle x)
+-}
 
 -- | This provides machinery for deconstructing an arbitrary 'Generic1' instance using a 'Decidable' 'Contravariant' functor.
 --
@@ -74,13 +112,13 @@ instance (Generic a, GDeciding q (Rep a)) => Deciding q a  where
 -- geq1 :: 'Deciding1' 'Eq' f => (a -> a -> 'Bool') -> f a -> f a -> 'Bool'
 -- geq1 f = 'getEquivalence' $ 'deciding1' (Proxy :: Proxy 'Eq') ('Equivalence' ('==')) ('Equivalence' f)
 -- @
-class (Generic1 t, GDeciding1 q (Rep1 t)) => Deciding1 q t where
+class (Generic1 t, GDeciding1 q (Rep1' t)) => Deciding1 q t where
 #ifndef HLINT
   deciding1 :: Decidable f => p q -> (forall b. q b => f b) -> f a -> f (t a)
 #endif
 
-instance (Generic1 t, GDeciding1 q (Rep1 t)) => Deciding1 q t where
-  deciding1 p q r = contramap from1 $ gdeciding1 p q r
+instance (Generic1 t, GDeciding1 q (Rep1' t), GG (Rep1 t)) => Deciding1 q t where
+  deciding1 p q r = contramap (swizzle . from1) $ gdeciding1 p q r
 
 class GDeciding q t where
 #ifndef HLINT
@@ -93,10 +131,10 @@ instance GDeciding q U1 where
 instance GDeciding q V1 where
   gdeciding _ _ = glose
 
-instance (GDeciding q f, GDeciding q g) => GDeciding q (f :*: g) where
+instance (GDeciding q f, GDeciding q g) => GDeciding q (f ::*: g) where
   gdeciding p q = gdivide (gdeciding p q) (gdeciding p q)
 
-instance (GDeciding q f, GDeciding q g) => GDeciding q (f :+: g) where
+instance (GDeciding q f, GDeciding q g) => GDeciding q (f ::+: g) where
   gdeciding p q = gchoose (gdeciding p q) (gdeciding p q)
 
 #ifndef HLINT
@@ -118,36 +156,29 @@ instance GDeciding1 q U1 where
 instance GDeciding1 q V1 where
   gdeciding1 _ _ _ = glose
 
-instance (GDeciding1 q f, GDeciding1 q g) => GDeciding1 q (f :*: g) where
+instance (GDeciding1 q f, GDeciding1 q g) => GDeciding1 q (f ::*: g) where
   gdeciding1 p q r = gdivide (gdeciding1 p q r) (gdeciding1 p q r)
 
-instance (GDeciding1 q f, GDeciding1 q g) => GDeciding1 q (f :+: g) where
+instance (GDeciding1 q f, GDeciding1 q g) => GDeciding1 q (f ::+: g) where
   gdeciding1 p q r = gchoose (gdeciding1 p q r) (gdeciding1 p q r)
 
-
+absurd1 :: V1 a -> b
+#if defined(HLINT) || (__GLASGOW_HASKELL__ < 708)
+absurd1 x = x `seq` error "impossible"
+#else
+absurd1 x = case x of
+#endif
 
 glose :: Decidable f => f (V1 a)
-#ifdef SAFE
-glose = lose (\ !_ -> error "impossible")
-#else
-glose = lose unsafeCoerce
-#endif
+glose = lose absurd1
 {-# INLINE glose #-}
 
-gdivide :: Divisible f => f (g a) -> f (h a) -> f ((g:*:h) a)
-#ifdef SAFE
-gdivide = divide (\(f:*:g) -> (f,g))
-#else
-gdivide = divide unsafeCoerce
-#endif
+gdivide :: Divisible f => f (g a) -> f (h a) -> f ((g::*:h) a)
+gdivide = divide unProd
 {-# INLINE gdivide #-}
 
-gchoose :: Decidable f => f (g a) -> f (h a) -> f ((g:+:h) a)
-#ifdef SAFE
-gchoose = choose (\xs -> case xs of L1 a -> Left a; R1 b -> Right b)
-#else
-gchoose = choose unsafeCoerce
-#endif
+gchoose :: Decidable f => f (g a) -> f (h a) -> f ((g::+:h) a)
+gchoose = choose unSum
 {-# INLINE gchoose #-}
 
 #ifndef HLINT


### PR DESCRIPTION
Previously, we (optionally) used `unsafeCoerce` to avoid passing
allocating functions to `divide` or `choose`, presumably because
those might not inline enough to make things efficient. But we should
be able to solve that problem, at least most of the time, by gathering
up all the relevant conversions in one spot so they're likely to
fuse with `from` or `from1`. That's the theory, anyway. I don't
know if it will hold up in practice.