### PR TITLE
Make it compile with MicroHs

### DIFF
--- a/contravariant.cabal
+++ b/contravariant.cabal
@@ -56,7 +56,11 @@ library
   exposed-modules:
     Data.Functor.Contravariant.Compose
     Data.Functor.Contravariant.Divisible
-    Data.Functor.Contravariant.Generic
+
+  if impl(ghc)
+    -- MicroHs doesn't support type families yet
+    exposed-modules:
+      Data.Functor.Contravariant.Generic
 
   if impl(ghc < 8.5)
     hs-source-dirs: old-src


### PR DESCRIPTION
`Data.Functor.Contravariant.Generics` makes extensive use of type families, which MicroHs doesn't support yet. Note that it's planned to support type families in the future (see https://github.com/augustss/MicroHs/issues/367), so this is hopefully only temporary.